### PR TITLE
Fixed a minor typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Comments Reply with ChatGPT(OpenAi) 1.0.0 - WordPress Plugin (Davinci-3)
+# Comments Reply with ChatGPT(OpenAI) 1.0.0 - WordPress Plugin (Davinci-3)
 ###### WordPress Plugins by Volkan Sah - Simple codings
 ![Screenshot](screenshot.png)
 ## Description
 
-Comments Reply with ChatGPT(OpenAi) is a plugin that uses OpenAI's GPT to automatically reply to comments on your WordPress website. The plugin adds a "Reply with WPWM OpenAI" button to the comment line actions, which when clicked, sends the comment text to OpenAI's ChatGPT API and returns a suggested response.
+Comments Reply with ChatGPT(OpenAI) is a plugin that uses OpenAI's GPT to automatically reply to comments on your WordPress website. The plugin adds a "Reply with WPWM OpenAI" button to the comment line actions, which when clicked, sends the comment text to OpenAI's ChatGPT API and returns a suggested response.
 
 
 ## Table of Contents


### PR DESCRIPTION
Title says it all. In the README.md file, there's a typo in "OpenAi", whereas it's officially referred to as "OpenAI".